### PR TITLE
Release 1.2.990005: HDDS-5804 backport

### DIFF
--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
 
   <artifactId>hdds-client</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Client Library</description>
   <name>Apache Ozone HDDS Client</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-common</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Common</description>
   <name>Apache Ozone HDDS Common</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-config</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Config Tools</description>
   <name>Apache Ozone HDDS Config</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-container-service</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Container Service</description>
   <name>Apache Ozone HDDS Container Service</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-docs</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone/HDDS Documentation</description>
   <name>Apache Ozone/HDDS Documentation</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-server-framework</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Server Framework
   </description>
   <name>Apache Ozone HDDS Server Framework</name>

--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-hadoop-dependency-client</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Hadoop client dependencies
   </description>
   <name>Apache Ozone HDDS Hadoop Client dependencies</name>

--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-hadoop-dependency-server</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Hadoop server dependencies
   </description>
   <name>Apache Ozone HDDS Hadoop Server dependencies</name>

--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-hadoop-dependency-test</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Hadoop test dependencies
   </description>
   <name>Apache Ozone HDDS Hadoop Test dependencies</name>

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-interface-admin</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Admin interface
   </description>
   <name>Apache Ozone HDDS Admin Interface</name>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-interface-client</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Client interface
   </description>
   <name>Apache Ozone HDDS Client Interface</name>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-interface-server</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Server interface
   </description>
   <name>Apache Ozone HDDS Server Interface</name>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
 
   <artifactId>hdds</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Project</description>
   <name>Apache Ozone HDDS</name>
   <packaging>pom</packaging>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-server-scm</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Storage Container Manager Server</description>
   <name>Apache Ozone HDDS SCM Server</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -135,7 +135,7 @@ public final class SCMContainerPlacementCapacity
           getNodeManager().getNodeStat(firstNodeDetails);
       SCMNodeMetric secondNodeMetric =
           getNodeManager().getNodeStat(secondNodeDetails);
-      datanodeDetails = firstNodeMetric.isGreater(secondNodeMetric.get())
+      datanodeDetails = !firstNodeMetric.isGreater(secondNodeMetric.get())
           ? firstNodeDetails : secondNodeDetails;
     }
     healthyNodes.remove(datanodeDetails);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -750,7 +750,8 @@ public class MockNodeManager implements NodeManager {
     SCMNodeStat stat = this.nodeMetricMap.get(datanodeDetails);
     if (stat != null) {
       aggregateStat.subtract(stat);
-      stat.getCapacity().add(size);
+      stat.getScmUsed().add(size);
+      stat.getRemaining().subtract(size);
       aggregateStat.add(stat);
       nodeMetricMap.put(datanodeDetails, stat);
     }
@@ -766,7 +767,8 @@ public class MockNodeManager implements NodeManager {
     SCMNodeStat stat = this.nodeMetricMap.get(datanodeDetails);
     if (stat != null) {
       aggregateStat.subtract(stat);
-      stat.getCapacity().subtract(size);
+      stat.getScmUsed().subtract(size);
+      stat.getRemaining().add(size);
       aggregateStat.add(stat);
       nodeMetricMap.put(datanodeDetails, stat);
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -148,10 +148,10 @@ public class TestSCMContainerPlacementCapacity {
 
     }
 
-    //datanode 4 has less space. Should be selected less times.
-    Assert.assertTrue(selectedCount.get(datanodes.get(3)) > selectedCount
+    //datanode 6 has more space than datanode 3 and datanode 4.
+    Assert.assertTrue(selectedCount.get(datanodes.get(3)) < selectedCount
         .get(datanodes.get(6)));
-    Assert.assertTrue(selectedCount.get(datanodes.get(4)) > selectedCount
+    Assert.assertTrue(selectedCount.get(datanodes.get(4)) < selectedCount
         .get(datanodes.get(6)));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
@@ -85,8 +85,8 @@ public class TestContainerPlacement {
         null, true, null);
 
     for (int x = 0; x < opsCount; x++) {
-      long containerSize = random.nextInt(100) * OzoneConsts.GB;
-      long metadataSize = random.nextInt(100) * OzoneConsts.GB;
+      long containerSize = random.nextInt(10) * OzoneConsts.GB;
+      long metadataSize = random.nextInt(10) * OzoneConsts.GB;
       List<DatanodeDetails> nodesCapacity =
           capacityPlacer.chooseDatanodes(new ArrayList<>(), null, nodesRequired,
               metadataSize, containerSize);

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>hdds-test-utils</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Test Utils</description>
   <name>Apache Ozone HDDS Test Utils</name>
   <packaging>jar</packaging>

--- a/hadoop-hdds/tools/pom.xml
+++ b/hadoop-hdds/tools/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
 
   <artifactId>hdds-tools</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Distributed Data Store Tools</description>
   <name>Apache Ozone HDDS Tools</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-client</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Client</description>
   <name>Apache Ozone Client</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-common</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Common</description>
   <name>Apache Ozone Common</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -20,10 +20,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-csi</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone CSI service</description>
   <name>Apache Ozone CSI service</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-datanode</artifactId>
   <name>Apache Ozone Datanode</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
 
   <properties>
     <spotbugs.skip>true</spotbugs.skip>

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-dist</artifactId>
   <name>Apache Ozone Distribution</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -20,9 +20,9 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>ozone-fault-injection-test</artifactId>
     <groupId>org.apache.ozone</groupId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Mini Ozone Chaos Tests</description>
   <name>Apache Ozone Mini Ozone Chaos Tests</name>
 

--- a/hadoop-ozone/fault-injection-test/network-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/network-tests/pom.xml
@@ -20,7 +20,7 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-network-tests</artifactId>
   <description>Apache Ozone Network Tests</description>

--- a/hadoop-ozone/fault-injection-test/pom.xml
+++ b/hadoop-ozone/fault-injection-test/pom.xml
@@ -20,10 +20,10 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-fault-injection-test</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Fault Injection Tests</description>
   <name>Apache Ozone Fault Injection Tests</name>
   <packaging>pom</packaging>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-insight</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Insight Tool</description>
   <name>Apache Ozone Insight Tool</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-integration-test</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Integration Tests</description>
   <name>Apache Ozone Integration Tests</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-interface-client</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Client interface</description>
   <name>Apache Ozone Client Interface</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -20,10 +20,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-interface-storage</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Storage Interface</description>
   <name>Apache Ozone Storage Interface</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-manager</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Manager Server</description>
   <name>Apache Ozone Manager Server</name>
   <packaging>jar</packaging>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-filesystem-common</artifactId>
   <name>Apache Ozone FileSystem Common</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop2</artifactId>
   <name>Apache Ozone FS Hadoop 2.x compatibility</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <properties>
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
   </properties>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop3</artifactId>
   <name>Apache Ozone FS Hadoop 3.x compatibility</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <properties>
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>
   </properties>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-filesystem-shaded</artifactId>
   <name>Apache Ozone FileSystem Shaded</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
 
   <properties>
     <shaded.prefix>org.apache.hadoop.ozone.shaded</shaded.prefix>

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-filesystem</artifactId>
   <name>Apache Ozone FileSystem</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -16,10 +16,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Project</description>
   <name>Apache Ozone</name>
   <packaging>pom</packaging>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <artifactId>ozone</artifactId>
     <groupId>org.apache.ozone</groupId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>ozone-reconcodegen</artifactId>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <name>Apache Ozone Recon</name>
   <modelVersion>4.0.0</modelVersion>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -19,12 +19,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-s3gateway</artifactId>
   <name>Apache Ozone S3 Gateway</name>
   <packaging>jar</packaging>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -20,10 +20,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>1.2.990004</version>
+    <version>1.2.990005</version>
   </parent>
   <artifactId>ozone-tools</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Tools</description>
   <name>Apache Ozone Tools</name>
   <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ozone</groupId>
   <artifactId>ozone-main</artifactId>
-  <version>1.2.990004</version>
+  <version>1.2.990005</version>
   <description>Apache Ozone Main</description>
   <name>Apache Ozone Main</name>
   <packaging>pom</packaging>
@@ -64,7 +64,7 @@
 
     <!-- version for hdds/ozone components -->
     <hdds.version>${ozone.version}</hdds.version>
-    <ozone.version>1.2.990004</ozone.version>
+    <ozone.version>1.2.990005</ozone.version>
     <ozone.release>Glacier</ozone.release>
     <declared.hdds.version>${hdds.version}</declared.hdds.version>
     <declared.ozone.version>${ozone.version}</declared.ozone.version>


### PR DESCRIPTION
This patch bumps version to 1.2.990005 for pfn-ozone-1.2 branch with HDDS-5804 backport.