### PR TITLE
Port HDDS-8993 to 1.3 branch

### DIFF
--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -130,11 +130,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="com.google.protobuf"
                          value="org.apache.ratis.thirdparty.com.google.protobuf"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto">
@@ -159,7 +160,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                       tofile="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto3"/>
                 <move file="target/generated-sources/java/proto3"
                       tofile="target/generated-sources/java"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -101,11 +101,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="com.google.protobuf"
                          value="org.apache.ratis.thirdparty.com.google.protobuf"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
@@ -118,7 +119,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                          value="org.apache.ratis.thirdparty.com.google.common"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/scm/proto">
                 </replace>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -112,11 +112,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
             <configuration>
-              <tasks>
+              <target>
                 <replace token="com.google.protobuf"
                          value="org.apache.hadoop.thirdparty.protobuf"
                          dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
@@ -147,7 +148,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                       tofile="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto3"/>
                 <move file="target/generated-sources/protobuf/java/proto3"
                       tofile="target/generated-sources/protobuf/java/"/>
-              </tasks>
+              </target>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -239,6 +239,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
     <checkstyle.version>9.3</checkstyle.version>
     <surefire.fork.timeout>1200</surefire.fork.timeout>
     <aws-java-sdk.version>1.12.261</aws-java-sdk.version>
@@ -1910,6 +1911,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
+        <version>${maven-antrun-plugin.version}</version>
         <executions>
           <execution>
             <id>create-testdirs</id>


### PR DESCRIPTION
Now we cannot build Ozone 1.3 branch due to [HDDS-8993](https://issues.apache.org/jira/browse/HDDS-8993). Manually ported its patch to 1.3 branch to add further original patches.