### PR TITLE
Build PFN Ozone 2.2.990001

### DIFF
--- a/dev-support/pom.xml
+++ b/dev-support/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-dev-support</artifactId>
   <name>Apache Ozone Dev Support</name>

--- a/hadoop-hdds/annotations/pom.xml
+++ b/hadoop-hdds/annotations/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
 
   <artifactId>hdds-annotation-processing</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Annotation Processing</name>
   <description>Apache Ozone annotation processing tools for validating custom

--- a/hadoop-hdds/cli-common/pom.xml
+++ b/hadoop-hdds/cli-common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-cli-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Common</name>
   <description>Apache Ozone CLI Common</description>

--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
 
   <artifactId>hdds-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Client</name>
   <description>Apache Ozone Distributed Data Store Client Library</description>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Common</name>
   <description>Apache Ozone Distributed Data Store Common</description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -714,6 +714,32 @@
     </description>
   </property>
   <property>
+    <name>ozone.om.liststatus.ratelimit</name>
+    <value>0</value>
+    <tag>OZONE, OM, PERFORMANCE</tag>
+    <description>
+      Rate limit in listStatus in seconds. listStatus operation in OM is
+      relatively a heavy operation, especially in case many keys in a bucket
+      or in a prefix.
+
+      Should be positive to turn on this feature. Otherwise, 0 or negative
+      integer will disable rate limiting.
+    </description>
+  </property>
+  <property>
+    <name>ozone.om.liststatus.ratelimit-timeout</name>
+    <value>8</value>
+    <tag>OZONE, OM, PERFORMANCE</tag>
+    <description>
+      The duration of a wait time in seconds when a client try to enter the
+      rate-limited section of listStatus operation.
+
+      The shorter this is, the less the OM gets loaded. The longer this
+      is, the less errors clients will get. Caveat: also, making this too
+      short may cause retry storm from S3Gateway to OM.
+    </description>
+  </property>
+  <property>
     <name>ozone.metadata.dirs</name>
     <value/>
     <tag>OZONE, OM, SCM, CONTAINER, STORAGE, REQUIRED</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -688,6 +688,32 @@
     </description>
   </property>
   <property>
+    <name>ozone.om.listkeys.ratelimit</name>
+    <value>0</value>
+    <tag>OZONE, OM, PERFORMANCE</tag>
+    <description>
+      Rate limit in listKeys in seconds. listKeys operation in OM is
+      relatively a heavy operation, especially in case many keys in a bucket
+      or in a prefix.
+
+      Should be positive to turn on this feature. Otherwise, 0 or negative
+      integer will disable rate limiting.
+    </description>
+  </property>
+  <property>
+    <name>ozone.om.listkeys.ratelimit-timeout</name>
+    <value>8</value>
+    <tag>OZONE, OM, PERFORMANCE</tag>
+    <description>
+      The duration of a wait time in seconds when a client try to enter the
+      rate-limited section of listKeys operation.
+
+      The shorter this is, the less the OM gets loaded. The longer this
+      is, the less errors clients will get. Caveat: also, making this too
+      short may cause retry storm from S3Gateway to OM.
+    </description>
+  </property>
+  <property>
     <name>ozone.metadata.dirs</name>
     <value/>
     <tag>OZONE, OM, SCM, CONTAINER, STORAGE, REQUIRED</tag>
@@ -4492,7 +4518,7 @@
       recon rocks DB containerKeyTable
     </description>
   </property>
-    
+
   <property>
     <name>ozone.recon.filesizecount.flush.db.max.threshold</name>
     <value>200000</value>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -692,7 +692,7 @@
     <value>0</value>
     <tag>OZONE, OM, PERFORMANCE</tag>
     <description>
-      Rate limit in listKeys in seconds. listKeys operation in OM is
+      Rate limit for listKeys in requests per second. listKeys operation in OM is
       relatively a heavy operation, especially in case many keys in a bucket
       or in a prefix.
 
@@ -705,7 +705,7 @@
     <value>8</value>
     <tag>OZONE, OM, PERFORMANCE</tag>
     <description>
-      The duration of a wait time in seconds when a client try to enter the
+      The maximum wait in seconds when a client tries to enter the
       rate-limited section of listKeys operation.
 
       The shorter this is, the less the OM gets loaded. The longer this
@@ -718,7 +718,7 @@
     <value>0</value>
     <tag>OZONE, OM, PERFORMANCE</tag>
     <description>
-      Rate limit in listStatus in seconds. listStatus operation in OM is
+      Rate limit for listStatus in requests per second. listStatus operation in OM is
       relatively a heavy operation, especially in case many keys in a bucket
       or in a prefix.
 
@@ -731,7 +731,7 @@
     <value>8</value>
     <tag>OZONE, OM, PERFORMANCE</tag>
     <description>
-      The duration of a wait time in seconds when a client try to enter the
+      The maximum wait in seconds when a client tries to enter the
       rate-limited section of listStatus operation.
 
       The shorter this is, the less the OM gets loaded. The longer this

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-config</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Config</name>
   <description>Apache Ozone Distributed Data Store Config Tools</description>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-container-service</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Container Service</name>
   <description>Apache Ozone Distributed Data Store Container Service</description>

--- a/hadoop-hdds/crypto-api/pom.xml
+++ b/hadoop-hdds/crypto-api/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
 
   <artifactId>hdds-crypto-api</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <name>Apache Ozone HDDS Crypto</name>
   <description>Apache Ozone Distributed Data Store cryptographic functions</description>
 

--- a/hadoop-hdds/crypto-default/pom.xml
+++ b/hadoop-hdds/crypto-default/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
 
   <artifactId>hdds-crypto-default</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <name>Apache Ozone HDDS Crypto - Default</name>
   <description>Default implementation of Apache Ozone Distributed Data Store's cryptographic functions</description>
 

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-docs</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Documentation</name>
   <description>Apache Ozone Documentation</description>

--- a/hadoop-hdds/erasurecode/pom.xml
+++ b/hadoop-hdds/erasurecode/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>hdds-erasurecode</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Erasurecode</name>
   <description>Apache Ozone Distributed Data Store Earsurecode utils</description>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-server-framework</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Server Framework</name>
   <description>Apache Ozone Distributed Data Store Server Framework</description>

--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-hadoop-dependency-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>pom</packaging>
   <name>Apache Ozone HDDS Hadoop Client dependencies</name>
   <description>Apache Ozone Distributed Data Store Hadoop client dependencies</description>

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-interface-admin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Admin Interface</name>
   <description>Apache Ozone Distributed Data Store Admin interface</description>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-interface-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Client Interface</name>
   <description>Apache Ozone Distributed Data Store Client interface</description>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-interface-server</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Server Interface</name>
   <description>Apache Ozone Distributed Data Store Server interface</description>

--- a/hadoop-hdds/managed-rocksdb/pom.xml
+++ b/hadoop-hdds/managed-rocksdb/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-managed-rocksdb</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Managed RocksDB</name>
   <description>Apache Ozone Managed RocksDB library</description>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
 
   <artifactId>hdds</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>pom</packaging>
   <name>Apache Ozone HDDS</name>
   <description>Apache Ozone Distributed Data Store Project</description>

--- a/hadoop-hdds/rocks-native/pom.xml
+++ b/hadoop-hdds/rocks-native/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-rocks-native</artifactId>
   <name>Apache Ozone HDDS RocksDB Tools</name>

--- a/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
+++ b/hadoop-hdds/rocksdb-checkpoint-differ/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
 
   <artifactId>rocksdb-checkpoint-differ</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Checkpoint Differ for RocksDB</name>
   <description>Apache Ozone Checkpoint Differ for RocksDB</description>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-server-scm</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS SCM Server</name>
   <description>Apache Ozone Distributed Data Store Storage Container Manager Server</description>

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>hdds-test-utils</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone HDDS Test Utils</name>
   <description>Apache Ozone Distributed Data Store Test Utils</description>

--- a/hadoop-ozone/cli-admin/pom.xml
+++ b/hadoop-ozone/cli-admin/pom.xml
@@ -17,12 +17,12 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
 
   <artifactId>ozone-cli-admin</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Admin</name>
   <description>Apache Ozone CLI Admin</description>

--- a/hadoop-ozone/cli-debug/pom.xml
+++ b/hadoop-ozone/cli-debug/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-cli-debug</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Debug Tools</name>
   <description>Apache Ozone Debug Tools</description>

--- a/hadoop-ozone/cli-interactive/pom.xml
+++ b/hadoop-ozone/cli-interactive/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-cli-interactive</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Interactive</name>
   <description>Apache Ozone top-level interactive CLI</description>

--- a/hadoop-ozone/cli-repair/pom.xml
+++ b/hadoop-ozone/cli-repair/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-cli-repair</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Repair Tools</name>
   <description>Apache Ozone Repair Tools</description>

--- a/hadoop-ozone/cli-shell/pom.xml
+++ b/hadoop-ozone/cli-shell/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-cli-shell</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CLI Shell</name>
   <description>Apache Ozone CLI Shell</description>

--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Client</name>
   <description>Apache Ozone Client</description>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Common</name>
   <description>Apache Ozone Common</description>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -703,6 +703,15 @@ public final class OMConfigKeys {
       "ozone.om.ratis.events.max.limit";
   public static final int OZONE_OM_RATIS_EVENTS_MAX_LIMIT_DEFAULT = 100;
 
+  // Rate limit listKeys in OzoneManager (req/sec)
+  public static final String OZONE_OM_LISTKEYS_RATELIMIT_KEY =
+          "ozone.om.listkeys.ratelimit";
+  public static final int OZONE_OM_LISTKEYS_RATELIMIT_DEFAULT = 0;
+
+  public static final String OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_KEY =
+          "ozone.om.listkeys.ratelimit-timeout";
+  public static final int OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_DEFAULT = 8; // seconds
+
   /**
    * Never constructed.
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -712,6 +712,15 @@ public final class OMConfigKeys {
           "ozone.om.listkeys.ratelimit-timeout";
   public static final int OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_DEFAULT = 8; // seconds
 
+  // Rate limit listStatus in OzoneManager (req/sec)
+  public static final String OZONE_OM_LISTSTATUS_RATELIMIT_KEY =
+          "ozone.om.liststatus.ratelimit";
+  public static final int OZONE_OM_LISTSTATUS_RATELIMIT_DEFAULT = 0;
+
+  public static final String OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_KEY =
+          "ozone.om.liststatus.ratelimit-timeout";
+  public static final int OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_DEFAULT = 8; // seconds
+
   /**
    * Never constructed.
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.WORLD;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -68,6 +69,8 @@ public final class OzoneAclUtil {
       // do nothing, since user has the permission, user can add ACL for selected groups later.
       LOG.warn("Failed to get primary group from user {}", ugi);
     }
+    // Add a default right
+    listOfAcls.add(OzoneAcl.of(WORLD, "", DEFAULT, ACLType.ALL));
     return listOfAcls;
   }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOzoneAclUtil.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
+import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.WORLD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -225,5 +226,15 @@ public class TestOzoneAclUtil {
     assertNotEquals(ozoneAcls.get(0).getAclScope(),
         ozoneAcls.get(1).getAclScope());
     assertEquals(ozoneAcls.get(0).getAclByteString(), ozoneAcls.get(1).getAclByteString());
+  }
+
+  @Test
+  public void testDefaultAclListContainsWorldDefaultAll() {
+    UserGroupInformation ugi = UserGroupInformation.createUserForTesting(
+        "test-user", new String[]{"test-group"});
+    OzoneAcl expected = OzoneAcl.of(WORLD, "", DEFAULT, ACLType.ALL);
+
+    assertTrue(OzoneAclUtil.getDefaultAclList(
+        ugi, newInstanceOf(OmConfig.class)).contains(expected));
   }
 }

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-csi</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone CSI service</name>
   <description>Apache Ozone CSI service</description>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-datanode</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Datanode</name>
 

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-dist</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Distribution</name>
   <properties>

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
 
   <artifactId>mini-chaos-tests</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <name>Apache Ozone Mini Ozone Chaos Tests</name>
   <description>Apache Ozone Mini Ozone Chaos Tests</description>
 

--- a/hadoop-ozone/fault-injection-test/network-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/network-tests/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-fault-injection-test</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-network-tests</artifactId>
   <packaging>jar</packaging>

--- a/hadoop-ozone/fault-injection-test/pom.xml
+++ b/hadoop-ozone/fault-injection-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-fault-injection-test</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>pom</packaging>
   <name>Apache Ozone Fault Injection Tests</name>
   <description>Apache Ozone Fault Injection Tests</description>

--- a/hadoop-ozone/freon/pom.xml
+++ b/hadoop-ozone/freon/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-freon</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Freon</name>
   <description>Apache Ozone Freon</description>

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -19,10 +19,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-httpfsgateway</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
 
   <name>Apache Ozone HttpFS</name>

--- a/hadoop-ozone/iceberg/pom.xml
+++ b/hadoop-ozone/iceberg/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-iceberg</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Iceberg Integration</name>
   <description>Apache Ozone Iceberg Integration</description>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-insight</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Insight Tool</name>
   <description>Apache Ozone Insight Tool</description>

--- a/hadoop-ozone/integration-test-recon/pom.xml
+++ b/hadoop-ozone/integration-test-recon/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-integration-test-recon</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Recon Integration Tests</name>
   <description>Apache Ozone Integration Tests with Recon</description>

--- a/hadoop-ozone/integration-test-s3/pom.xml
+++ b/hadoop-ozone/integration-test-s3/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-integration-test-s3</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Integration Tests</name>
   <description>Apache Ozone Integration Tests with S3 Gateway</description>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-integration-test</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Integration Tests</name>
   <description>Apache Ozone Integration Tests</description>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-interface-client</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Client Interface</name>
   <description>Apache Ozone Client interface</description>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-interface-storage</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Storage Interface</name>
   <description>Apache Ozone Storage Interface</description>

--- a/hadoop-ozone/mini-cluster/pom.xml
+++ b/hadoop-ozone/mini-cluster/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-mini-cluster</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Mini Cluster</name>
   <description>Apache Ozone Mini Cluster for Integration Tests</description>

--- a/hadoop-ozone/multitenancy-ranger/pom.xml
+++ b/hadoop-ozone/multitenancy-ranger/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-multitenancy-ranger</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Multitenancy with Ranger</name>
   <description>Implementation of multitenancy for Apache Ozone Manager Server using Apache Ranger</description>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-manager</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Manager Server</name>
   <description>Apache Ozone Manager Server</description>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMRequestRateLimiter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMRequestRateLimiter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.util.concurrent.RateLimiter;
+import java.time.Duration;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ipc_.RetriableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Rate limiter for expensive read-only OM requests. */
+final class OMRequestRateLimiter {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMRequestRateLimiter.class);
+
+  private final String operation;
+  private final RateLimiter rateLimiter;
+  private final Duration timeout;
+
+  private OMRequestRateLimiter(String operation, RateLimiter rateLimiter,
+      Duration timeout) {
+    this.operation = operation;
+    this.rateLimiter = rateLimiter;
+    this.timeout = timeout;
+  }
+
+  static OMRequestRateLimiter fromConfiguration(
+      ConfigurationSource configuration, String operation,
+      String rateLimitKey, int defaultRateLimit,
+      String timeoutKey, int defaultTimeout) {
+    int permitsPerSecond = configuration.getInt(
+        rateLimitKey, defaultRateLimit);
+    if (permitsPerSecond <= 0) {
+      LOG.info("{} rate limit disabled: permitsPerSecond={}",
+          operation, permitsPerSecond);
+      return new OMRequestRateLimiter(operation, null, Duration.ZERO);
+    }
+
+    int timeoutSeconds = configuration.getInt(timeoutKey, defaultTimeout);
+    if (timeoutSeconds < 0) {
+      throw new IllegalArgumentException(
+          timeoutKey + " must be zero or greater");
+    }
+
+    Duration timeout = Duration.ofSeconds(timeoutSeconds);
+    LOG.info("{} rate limit enabled: permitsPerSecond={}, timeout={}",
+        operation, permitsPerSecond, timeout);
+    return new OMRequestRateLimiter(
+        operation, RateLimiter.create(permitsPerSecond), timeout);
+  }
+
+  void acquire() throws RetriableException {
+    if (rateLimiter != null && !rateLimiter.tryAcquire(timeout)) {
+      throw new RetriableException(
+          "Rate limit exceeded for " + operation);
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -417,6 +417,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private ExecutorService edekCacheLoader = null;
   private Optional<RateLimiter> listKeysRateLimiter;
   private Duration listKeysRateLimiterTimeout;
+  private Optional<RateLimiter> listStatusRateLimiter;
+  private Duration listStatusRateLimiterTimeout;
 
   /**
    * OM super user / admin list.
@@ -619,6 +621,24 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } else {
       listKeysRateLimiter = Optional.empty();
       LOG.info("ratelimit disabled: ratelimit={}", listKeysRateLimit);
+    }
+
+    // Ratelimit for listStatus
+    int listStatusRateLimit = configuration.getInt(
+            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_KEY,
+            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_DEFAULT);
+    if (listStatusRateLimit > 0) {
+      listStatusRateLimiter = Optional.of(RateLimiter.create(listStatusRateLimit));
+
+      int timeout = configuration.getInt(
+              OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_KEY,
+              OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_DEFAULT);
+      listStatusRateLimiterTimeout = Duration.ofSeconds(timeout);
+      LOG.info("ratelimit enbled: ratelimit={}s timeout={}",
+              listStatusRateLimit, listStatusRateLimiterTimeout);
+    } else {
+      listStatusRateLimiter = Optional.empty();
+      LOG.info("ratelimit disabled: ratelimit={}", listStatusRateLimit);
     }
 
     this.isStrictS3 = conf.getBoolean(
@@ -4080,6 +4100,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,
       String startKey, long numEntries, boolean allowPartialPrefixes)
       throws IOException {
+    if (listStatusRateLimiter.isPresent()) {
+      boolean ok = listStatusRateLimiter.get().tryAcquire(listStatusRateLimiterTimeout);
+      if (!ok) {
+        throw new RetriableException("Rate limit exceeded for listStatus");
+      }
+    }
+
     try (UncheckedAutoCloseableSupplier<IOmMetadataReader> rcReader =
         getReader(args)) {
       return rcReader.get().listStatus(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -115,7 +115,6 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.BlockingService;
 import java.io.BufferedWriter;
@@ -225,7 +224,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
-import org.apache.hadoop.ipc_.RetriableException;
 import org.apache.hadoop.ipc_.Server;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.ozone.OmUtils;
@@ -415,10 +413,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private PrefixManagerImpl prefixManager;
   private final UpgradeFinalizer<OzoneManager> upgradeFinalizer;
   private ExecutorService edekCacheLoader = null;
-  private Optional<RateLimiter> listKeysRateLimiter;
-  private Duration listKeysRateLimiterTimeout;
-  private Optional<RateLimiter> listStatusRateLimiter;
-  private Duration listStatusRateLimiterTimeout;
+  private OMRequestRateLimiter listKeysRateLimiter;
+  private OMRequestRateLimiter listStatusRateLimiter;
 
   /**
    * OM super user / admin list.
@@ -606,40 +602,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     this.grpcBlockTokenEnabled = conf.getBoolean(HDDS_BLOCK_TOKEN_ENABLED,
         HDDS_BLOCK_TOKEN_ENABLED_DEFAULT);
 
-    int listKeysRateLimit = configuration.getInt(
+    listKeysRateLimiter = OMRequestRateLimiter.fromConfiguration(
+        configuration, "listKeys",
         OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_KEY,
-        OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_DEFAULT);
-    if (listKeysRateLimit > 0) {
-      listKeysRateLimiter = Optional.of(RateLimiter.create(listKeysRateLimit));
-
-      int timeout = configuration.getInt(
-          OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_KEY,
-          OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_DEFAULT);
-      listKeysRateLimiterTimeout = Duration.ofSeconds(timeout);
-      LOG.info("ratelimit enbled: ratelimit={}s timeout={}",
-          listKeysRateLimit, listKeysRateLimiterTimeout);
-    } else {
-      listKeysRateLimiter = Optional.empty();
-      LOG.info("ratelimit disabled: ratelimit={}", listKeysRateLimit);
-    }
-
-    // Ratelimit for listStatus
-    int listStatusRateLimit = configuration.getInt(
-            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_KEY,
-            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_DEFAULT);
-    if (listStatusRateLimit > 0) {
-      listStatusRateLimiter = Optional.of(RateLimiter.create(listStatusRateLimit));
-
-      int timeout = configuration.getInt(
-              OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_KEY,
-              OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_DEFAULT);
-      listStatusRateLimiterTimeout = Duration.ofSeconds(timeout);
-      LOG.info("ratelimit enbled: ratelimit={}s timeout={}",
-              listStatusRateLimit, listStatusRateLimiterTimeout);
-    } else {
-      listStatusRateLimiter = Optional.empty();
-      LOG.info("ratelimit disabled: ratelimit={}", listStatusRateLimit);
-    }
+        OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_DEFAULT,
+        OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_KEY,
+        OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_DEFAULT);
+    listStatusRateLimiter = OMRequestRateLimiter.fromConfiguration(
+        configuration, "listStatus",
+        OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_KEY,
+        OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_DEFAULT,
+        OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_KEY,
+        OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_DEFAULT);
 
     this.isStrictS3 = conf.getBoolean(
         OZONE_OM_NAMESPACE_STRICT_S3,
@@ -3153,12 +3127,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public ListKeysResult listKeys(String volumeName, String bucketName,
                                  String startKey, String keyPrefix, int maxKeys)
       throws IOException {
-    if (listKeysRateLimiter.isPresent()) {
-      boolean ok = listKeysRateLimiter.get().tryAcquire(listKeysRateLimiterTimeout);
-      if (!ok) {
-        throw new RetriableException("Rate limit exceeded for listKeys");
-      }
-    }
+    listKeysRateLimiter.acquire();
     try (UncheckedAutoCloseableSupplier<IOmMetadataReader> rcReader =
              getReader(volumeName, bucketName, keyPrefix)) {
       return rcReader.get().listKeys(
@@ -4100,12 +4069,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,
       String startKey, long numEntries, boolean allowPartialPrefixes)
       throws IOException {
-    if (listStatusRateLimiter.isPresent()) {
-      boolean ok = listStatusRateLimiter.get().tryAcquire(listStatusRateLimiterTimeout);
-      if (!ok) {
-        throw new RetriableException("Rate limit exceeded for listStatus");
-      }
-    }
+    listStatusRateLimiter.acquire();
 
     try (UncheckedAutoCloseableSupplier<IOmMetadataReader> rcReader =
         getReader(args)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -115,6 +115,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.util.concurrent.RateLimiter;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.BlockingService;
 import java.io.BufferedWriter;
@@ -224,6 +225,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc_.ProtobufRpcEngine;
 import org.apache.hadoop.ipc_.RPC;
+import org.apache.hadoop.ipc_.RetriableException;
 import org.apache.hadoop.ipc_.Server;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.ozone.OmUtils;
@@ -413,6 +415,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private PrefixManagerImpl prefixManager;
   private final UpgradeFinalizer<OzoneManager> upgradeFinalizer;
   private ExecutorService edekCacheLoader = null;
+  private Optional<RateLimiter> listKeysRateLimiter;
+  private Duration listKeysRateLimiterTimeout;
 
   /**
    * OM super user / admin list.
@@ -599,6 +603,24 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT);
     this.grpcBlockTokenEnabled = conf.getBoolean(HDDS_BLOCK_TOKEN_ENABLED,
         HDDS_BLOCK_TOKEN_ENABLED_DEFAULT);
+
+    int listKeysRateLimit = configuration.getInt(
+        OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_KEY,
+        OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_DEFAULT);
+    if (listKeysRateLimit > 0) {
+      listKeysRateLimiter = Optional.of(RateLimiter.create(listKeysRateLimit));
+
+      int timeout = configuration.getInt(
+          OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_KEY,
+          OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_DEFAULT);
+      listKeysRateLimiterTimeout = Duration.ofSeconds(timeout);
+      LOG.info("ratelimit enbled: ratelimit={}s timeout={}",
+          listKeysRateLimit, listKeysRateLimiterTimeout);
+    } else {
+      listKeysRateLimiter = Optional.empty();
+      LOG.info("ratelimit disabled: ratelimit={}", listKeysRateLimit);
+    }
+
     this.isStrictS3 = conf.getBoolean(
         OZONE_OM_NAMESPACE_STRICT_S3,
         OZONE_OM_NAMESPACE_STRICT_S3_DEFAULT);
@@ -3111,6 +3133,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public ListKeysResult listKeys(String volumeName, String bucketName,
                                  String startKey, String keyPrefix, int maxKeys)
       throws IOException {
+    if (listKeysRateLimiter.isPresent()) {
+      boolean ok = listKeysRateLimiter.get().tryAcquire(listKeysRateLimiterTimeout);
+      if (!ok) {
+        throw new RetriableException("Rate limit exceeded for listKeys");
+      }
+    }
     try (UncheckedAutoCloseableSupplier<IOmMetadataReader> rcReader =
              getReader(volumeName, bucketName, keyPrefix)) {
       return rcReader.get().listKeys(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMRequestRateLimiter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMRequestRateLimiter.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ipc_.RetriableException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestOMRequestRateLimiter {
+
+  private static Stream<Arguments> operations() {
+    return Stream.of(
+        Arguments.of("listKeys",
+            OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_KEY,
+            OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_DEFAULT,
+            OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_KEY,
+            OMConfigKeys.OZONE_OM_LISTKEYS_RATELIMIT_TIMEOUT_DEFAULT),
+        Arguments.of("listStatus",
+            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_KEY,
+            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_DEFAULT,
+            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_KEY,
+            OMConfigKeys.OZONE_OM_LISTSTATUS_RATELIMIT_TIMEOUT_DEFAULT));
+  }
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void disabledLimiterAllowsRepeatedRequests(String operation,
+      String rateLimitKey, int defaultRateLimit,
+      String timeoutKey, int defaultTimeout) {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.setInt(rateLimitKey, 0);
+
+    OMRequestRateLimiter limiter = OMRequestRateLimiter.fromConfiguration(
+        configuration, operation, rateLimitKey, defaultRateLimit,
+        timeoutKey, defaultTimeout);
+
+    assertDoesNotThrow(limiter::acquire);
+    assertDoesNotThrow(limiter::acquire);
+  }
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void zeroTimeoutRejectsImmediatelyWhenRateIsExceeded(String operation,
+      String rateLimitKey, int defaultRateLimit,
+      String timeoutKey, int defaultTimeout) {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.setInt(rateLimitKey, 1);
+    configuration.setInt(timeoutKey, 0);
+
+    OMRequestRateLimiter limiter = OMRequestRateLimiter.fromConfiguration(
+        configuration, operation, rateLimitKey, defaultRateLimit,
+        timeoutKey, defaultTimeout);
+
+    assertDoesNotThrow(limiter::acquire);
+    assertThrows(RetriableException.class, limiter::acquire);
+  }
+
+  @ParameterizedTest
+  @MethodSource("operations")
+  void negativeTimeoutIsRejected(String operation,
+      String rateLimitKey, int defaultRateLimit,
+      String timeoutKey, int defaultTimeout) {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.setInt(rateLimitKey, 1);
+    configuration.setInt(timeoutKey, -1);
+
+    assertThrows(IllegalArgumentException.class,
+        () -> OMRequestRateLimiter.fromConfiguration(
+            configuration, operation, rateLimitKey, defaultRateLimit,
+            timeoutKey, defaultTimeout));
+  }
+}

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-filesystem-common</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem Common</name>
   <properties>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop2</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 2.x compatibility</name>
   <dependencies>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-filesystem-hadoop3</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FS Hadoop 3.x compatibility</name>
   <properties>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-filesystem-shaded</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem Shaded</name>
 

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -17,11 +17,11 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>hdds-hadoop-dependency-client</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
     <relativePath>../../hadoop-hdds/hadoop-dependency-client</relativePath>
   </parent>
   <artifactId>ozone-filesystem</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone FileSystem</name>
   <properties>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone-main</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>pom</packaging>
   <name>Apache Ozone</name>
   <description>Apache Ozone Project</description>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-reconcodegen</artifactId>
   <name>Apache Ozone Recon CodeGen</name>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-recon</artifactId>
   <name>Apache Ozone Recon</name>

--- a/hadoop-ozone/s3-secret-store/pom.xml
+++ b/hadoop-ozone/s3-secret-store/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-s3-secret-store</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Secret Store</name>
   <properties>

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-s3gateway</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone S3 Gateway</name>
   <properties>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-tools</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Tools</name>
   <description>Apache Ozone Tools</description>

--- a/hadoop-ozone/vapor/pom.xml
+++ b/hadoop-ozone/vapor/pom.xml
@@ -17,10 +17,10 @@
   <parent>
     <groupId>org.apache.ozone</groupId>
     <artifactId>ozone</artifactId>
-    <version>2.2.0</version>
+    <version>2.2.990001</version>
   </parent>
   <artifactId>ozone-vapor</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>jar</packaging>
   <name>Apache Ozone Vapor</name>
   <description>Apache Ozone server-side load testing tools</description>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.ozone</groupId>
   <artifactId>ozone-main</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.990001</version>
   <packaging>pom</packaging>
   <name>Apache Ozone Main</name>
   <description>Apache Ozone Main</description>
@@ -166,7 +166,7 @@
     <ozone.release>Katmai</ozone.release>
     <ozone.shaded.native.prefix>org_apache_ozone_shaded</ozone.shaded.native.prefix>
     <ozone.shaded.prefix>org.apache.ozone.shaded</ozone.shaded.prefix>
-    <ozone.version>2.2.0</ozone.version>
+    <ozone.version>2.2.990001</ozone.version>
     <!--
       4.7.6: https://github.com/remkop/picocli/issues/2309
       4.7.7: https://github.com/remkop/picocli/issues/2407
@@ -174,7 +174,7 @@
     <picocli.version>4.7.5</picocli.version>
     <pmd.version>3.28.0</pmd.version>
     <!-- Enable Reproducible Builds mode -->
-    <project.build.outputTimestamp>2026-06-15T02:15:54Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-08-06T02:54:51Z</project.build.outputTimestamp>
     <!-- platform encoding override -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## Summary

- build PFN Ozone `2.2.990001` from the official Apache Ozone `ozone-2.2.0` tag (`95bda680b952d164706dc0b8debbcad805b6a32c`)
- forward-port the PFN listKeys/listStatus rate limits and default WORLD key ACL
- share and test the OM request rate limiter, including disabled, immediate rejection, and invalid-timeout behavior
- bump every module to the PFN package version

This PR prepares the source and artifact only; it does not deploy the package.

## Provenance

- review base `apache-ozone-2.2.0` points exactly at the official tag commit
- official source archive SHA-512: verified
- official source archive GPG signature: good signature from Hui Fei (`26B5 29DD C5EF E92C A3B3 F29C 9076 368B C5BA 9C4F`)
- embedded build revision: `c996d654ef55a15dbbdc5af4c4baf169749eb07b`

## Validation

- targeted OM rate-limiter and ACL tests pass under Java 17 and Java 21
- Java 17 `-Pdist` clean build: all 60 reactor modules pass
- local distribution: `ozone-2.2.990001.tar.gz` (390,441,072 bytes)
- local SHA-256: `379f4b89639e9308e371529957917262244588f123fcfef39baa11ac11ca800c`
- extracted `bin/ozone version` reports `2.2.990001` and revision `c996d654ef55a15dbbdc5af4c4baf169749eb07b`

## Before merge

- [ ] arrange an independent/CI build review (this repository currently registers no PR checks)
- [ ] publish the reviewed tarball to the internal package location
- [ ] record and verify the published SHA-256 before enabling the PFS0 canary
